### PR TITLE
fix: make deprecated fields optional

### DIFF
--- a/src/schema/unitData.schema.ts
+++ b/src/schema/unitData.schema.ts
@@ -8,6 +8,7 @@ export const unitDataSchema = z.object({
   description: z.string().nullable(),
   slug: z.string(),
   tags: z.array(z.number()).nullable(),
+  deprecated_fields: z.record(z.unknown()).nullable().optional(),
   title: z.string(),
   _state: _stateSchema,
   _cohort: _cohortSchema,


### PR DESCRIPTION
Added an optional deprecated_fields to the unitData schema. 
This needs to be exposed in order to surface the expired field for the legacy pupil browse experience