### PR TITLE
feat: add expired field

### DIFF
--- a/src/fixtures/syntheticUnitvariantsWithLessonIds.fixture.ts
+++ b/src/fixtures/syntheticUnitvariantsWithLessonIds.fixture.ts
@@ -18,5 +18,6 @@ export const syntheticUnitvariantsWithLessonIdsFixture = ({
   supplementary_data: {
     unit_order: 1,
   },
+  expired: false,
   ...overrides,
 });

--- a/src/schema/syntheticUnitvariantsWithLessonIds.schema.ts
+++ b/src/schema/syntheticUnitvariantsWithLessonIds.schema.ts
@@ -14,6 +14,7 @@ export const syntheticUnitvariantsWithLessonIdsSchema = z.object({
   supplementary_data: z.object({
     unit_order: z.number(),
   }),
+  expired: z.boolean(),
 });
 
 export type syntheticUnitvariantsWithLessonIds = z.infer<


### PR DESCRIPTION
Add an expired field to syntheticUnitvariantsWithLessonIdsSchema corresponding to an upcoming mv change in DBT. 
This will count the number of expired lessons in a unit and if all are expired the unit will be marked as expired.