### PR TITLE
feat: add base_slug to syntheticUnitvariantsWithLessonIds

### DIFF
--- a/src/fixtures/syntheticUnitvariantsWithLessonIds.fixture.ts
+++ b/src/fixtures/syntheticUnitvariantsWithLessonIds.fixture.ts
@@ -8,6 +8,7 @@ export const syntheticUnitvariantsWithLessonIdsFixture = ({
 }: {
   overrides?: Partial<syntheticUnitvariantsWithLessonIds>;
 } = {}): syntheticUnitvariantsWithLessonIds => ({
+  base_slug: "base-slug",
   unit_slug: "unit-slug",
   programme_slug: "programme-slug",
   is_legacy: false,

--- a/src/schema/syntheticUnitvariantsWithLessonIds.schema.ts
+++ b/src/schema/syntheticUnitvariantsWithLessonIds.schema.ts
@@ -4,6 +4,7 @@ import { unitvariantSchema } from "./unitvariant.schema";
 import { programmeFieldsSchema } from "./programmeFields.schema";
 
 export const syntheticUnitvariantsWithLessonIdsSchema = z.object({
+  base_slug: z.string(),
   unit_slug: z.string(),
   programme_slug: z.string(),
   is_legacy: z.boolean(),


### PR DESCRIPTION
Add `base_slug` so that multiple related units can be displayed on the same page within pupil units listing page.