### PR TITLE
feat: allow subjectcategories to also be strings

### DIFF
--- a/src/fixtures/unitData.fixture.ts
+++ b/src/fixtures/unitData.fixture.ts
@@ -13,6 +13,6 @@ export const unitDataFixture = ({
   title: "unit-title",
   _state: "published",
   _cohort: "2023-2024",
-  subjectcategories: null,
+  subjectcategories: [1, 2, 3],
   ...overrides,
 });

--- a/src/schema/unitData.schema.ts
+++ b/src/schema/unitData.schema.ts
@@ -10,7 +10,7 @@ export const unitDataSchema = z.object({
   tags: z.array(z.number()).nullable(),
   deprecated_fields: z.record(z.unknown()).nullable().optional(),
   title: z.string(),
-  subjectcategories: z.array(z.number()).nullable(),
+  subjectcategories: z.array(z.union([z.number(), z.string()])).nullable(),
   _state: _stateSchema,
   _cohort: _cohortSchema,
 });


### PR DESCRIPTION
Allowing subjectcategories in unitData to be strings as well as numbers. 
This allows us to denormalize the subjectcategories in place so that they can meaningfully be used by the client. 