### PR TITLE
Feat/ctc 33/mv suv lessons by ks

### DIFF
--- a/src/fixtures/syntheticUnitvariantLessonsByKs.fixture.ts
+++ b/src/fixtures/syntheticUnitvariantLessonsByKs.fixture.ts
@@ -2,25 +2,21 @@ import { SyntheticUnitvariantLessonsByKs } from "@/schema/syntheticUnitvariantLe
 import { lessonDataFixture } from "./lessonData.fixture";
 import { unitDataFixture } from "./unitData.fixture";
 import { programmeFieldsFixture } from "./programmeFields.fixture";
-import { unitvariantFixture } from "./unitvariant.fixture";
 
 export const syntheticUnitvariantLessonsByKsFixture = ({
   overrides = {},
 }: {
   overrides?: Partial<SyntheticUnitvariantLessonsByKs>;
 } = {}): SyntheticUnitvariantLessonsByKs => ({
-  unitvariant_id: 1,
   lesson_slug: "lesson-slug",
   unit_slug: "unit-slug",
   programme_slug: "programme-slug",
+  programme_slug_by_year: ["programme-slug-year"],
   is_legacy: false,
   lesson_data: lessonDataFixture(),
   unit_data: unitDataFixture(),
-  null_unitvariant: unitvariantFixture(),
+  null_unitvariant_id: 1,
   programme_fields: programmeFieldsFixture(),
-  supplementary_data: {
-    unit_order: 1,
-    order_in_unit: 1,
-  },
+  order_in_unit: 1,
   ...overrides,
 });

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -13,4 +13,4 @@ export * from "./lessonContent.schema";
 export * from "./syntheticProgrammesByYear.schema";
 export * from "./threadsByUnit.schema";
 export * from "./programmeListing.schema";
-export * from "./syntheticUnitvariantLessonsByKs.schema";
+export * from "./syntheticUnitvariantLessonsByKs.schema.old";

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -14,3 +14,4 @@ export * from "./syntheticProgrammesByYear.schema";
 export * from "./threadsByUnit.schema";
 export * from "./programmeListing.schema";
 export * from "./syntheticUnitvariantLessonsByKs.schema.old";
+export * from "./syntheticUnitvariantLessonsByKs.schema";

--- a/src/schema/programmeListing.schema.ts
+++ b/src/schema/programmeListing.schema.ts
@@ -1,4 +1,4 @@
-import { syntheticUnitvariantLessonsByKsSchema } from "./syntheticUnitvariantLessonsByKs.schema";
+import { syntheticUnitvariantLessonsByKsSchema } from "./syntheticUnitvariantLessonsByKs.schema.old";
 import { z } from "zod";
 
 export const programmeListingResponseSchema =

--- a/src/schema/programmeListing.schema.ts
+++ b/src/schema/programmeListing.schema.ts
@@ -1,8 +1,8 @@
-import { syntheticUnitvariantLessonsByKsSchema } from "./syntheticUnitvariantLessonsByKs.schema.old";
+import { syntheticUnitvariantLessonsByKsSchemaOld } from "./syntheticUnitvariantLessonsByKs.schema.old";
 import { z } from "zod";
 
 export const programmeListingResponseSchema =
-  syntheticUnitvariantLessonsByKsSchema.pick({
+  syntheticUnitvariantLessonsByKsSchemaOld.pick({
     lesson_data: true,
     programme_fields: true,
     is_legacy: true,

--- a/src/schema/syntheticUnitvariantLessonsByKs.schema.old.ts
+++ b/src/schema/syntheticUnitvariantLessonsByKs.schema.old.ts
@@ -3,7 +3,7 @@ import { syntheticUnitvariantLessonsSchema } from "./syntheticUnitvariantLessons
 import { unitvariantSchema } from "./unitvariant.schema";
 import { programmeFieldsSchema } from "./programmeFields.schema";
 
-export const syntheticUnitvariantLessonsByKsSchema = z.object({
+export const syntheticUnitvariantLessonsByKsSchemaOld = z.object({
   ...syntheticUnitvariantLessonsSchema.omit({ null_unitvariant_id: true })
     .shape,
   unitvariant_id: z.number().nullable(),
@@ -17,6 +17,6 @@ export const syntheticUnitvariantLessonsByKsSchema = z.object({
   }),
 });
 
-export type SyntheticUnitvariantLessonsByKs = z.infer<
-  typeof syntheticUnitvariantLessonsByKsSchema
+export type SyntheticUnitvariantLessonsByKsOld = z.infer<
+  typeof syntheticUnitvariantLessonsByKsSchemaOld
 >;

--- a/src/schema/syntheticUnitvariantLessonsByKs.schema.old.ts
+++ b/src/schema/syntheticUnitvariantLessonsByKs.schema.old.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { syntheticUnitvariantLessonsSchema } from "./syntheticUnitvariantLessons.schema";
+import { unitvariantSchema } from "./unitvariant.schema";
+import { programmeFieldsSchema } from "./programmeFields.schema";
+
+export const syntheticUnitvariantLessonsByKsSchema = z.object({
+  ...syntheticUnitvariantLessonsSchema.omit({ null_unitvariant_id: true })
+    .shape,
+  unitvariant_id: z.number().nullable(),
+  null_unitvariant: unitvariantSchema,
+  programme_fields: programmeFieldsSchema.omit({
+    pathway: true,
+    pathway_description: true,
+    pathway_display_order: true,
+    pathway_id: true,
+    pathway_slug: true,
+  }),
+});
+
+export type SyntheticUnitvariantLessonsByKs = z.infer<
+  typeof syntheticUnitvariantLessonsByKsSchema
+>;

--- a/src/schema/syntheticUnitvariantLessonsByKs.schema.ts
+++ b/src/schema/syntheticUnitvariantLessonsByKs.schema.ts
@@ -1,20 +1,10 @@
 import { z } from "zod";
 import { syntheticUnitvariantLessonsSchema } from "./syntheticUnitvariantLessons.schema";
-import { unitvariantSchema } from "./unitvariant.schema";
-import { programmeFieldsSchema } from "./programmeFields.schema";
 
 export const syntheticUnitvariantLessonsByKsSchema = z.object({
-  ...syntheticUnitvariantLessonsSchema.omit({ null_unitvariant_id: true })
-    .shape,
-  unitvariant_id: z.number().nullable(),
-  null_unitvariant: unitvariantSchema,
-  programme_fields: programmeFieldsSchema.omit({
-    pathway: true,
-    pathway_description: true,
-    pathway_display_order: true,
-    pathway_id: true,
-    pathway_slug: true,
-  }),
+  ...syntheticUnitvariantLessonsSchema.omit({ supplementary_data: true }).shape,
+  programme_slug_by_year: z.string().array(),
+  order_in_unit: z.number(),
 });
 
 export type SyntheticUnitvariantLessonsByKs = z.infer<


### PR DESCRIPTION
### Job story

I want mv_synthetic_unitvariant_lessons_by_keystage to use new views so that I can have pathways, features, overrides and exceptions and all that good stuff

### Implementation

These changes support the new lessons by keystage mv. I have deprecated the old schema but not deleted it so that it can still be used in OWA for progressive deployment of mvs