### PR TITLE
CTC-44: optionally adds lesson guide schema updates

### DIFF
--- a/src/fixtures/lessonContent.fixture.ts
+++ b/src/fixtures/lessonContent.fixture.ts
@@ -92,5 +92,9 @@ export const lessonContentFixture = ({
   has_worksheet_asset_object: true,
   geo_restricted: false,
   login_required: false,
+  lesson_guide_asset_id: 1,
+  has_lesson_guide_asset_object: true,
+  lesson_guide_asset_object_url: "lesson-guide-asset-object-url",
+  has_lesson_guide_google_drive_downloadable_version: false,
   ...overrides,
 });

--- a/src/schema/lessonContent.schema.ts
+++ b/src/schema/lessonContent.schema.ts
@@ -89,6 +89,7 @@ export const lessonContentSchema = z.object({
   supplementary_asset_object_url: z.string().nullable(),
   worksheet_asset_object_url: z.string().nullable(),
   slide_deck_asset_object_url: z.string().nullable(),
+  // currently set to optional whilst PE lessons are unpublished so as not to break lesson pages
   lesson_guide_asset_id: z.number().nullable().optional(),
   has_lesson_guide_asset_object: z.boolean().nullable().optional(),
   lesson_guide_asset_object_url: z.string().nullable().optional(),

--- a/src/schema/lessonContent.schema.ts
+++ b/src/schema/lessonContent.schema.ts
@@ -89,6 +89,13 @@ export const lessonContentSchema = z.object({
   supplementary_asset_object_url: z.string().nullable(),
   worksheet_asset_object_url: z.string().nullable(),
   slide_deck_asset_object_url: z.string().nullable(),
+  lesson_guide_asset_id: z.number().nullable().optional(),
+  has_lesson_guide_asset_object: z.boolean().nullable().optional(),
+  lesson_guide_asset_object_url: z.string().nullable().optional(),
+  has_lesson_guide_google_drive_downloadable_version: z
+    .boolean()
+    .nullable()
+    .optional(),
   geo_restricted: z.boolean().nullable(),
   login_required: z.boolean().nullable(),
 });


### PR DESCRIPTION
### Description 

Updates lesson content schema to optionally add lesson guide data so that the data can be viewable on OWA.

Initially set to optional so as not to break current website as this will only be available on the new lesson_content_mv

### PR
https://www.notion.so/oaknationalacademy/I-want-to-see-the-lesson-guide-on-a-lesson-12f26cc4e1b180c4b443e8873f7d956f