### PR TITLE
feat: add unitvariant id to schema

### DIFF
--- a/src/fixtures/syntheticUnitvariantLessonsByKs.fixture.ts
+++ b/src/fixtures/syntheticUnitvariantLessonsByKs.fixture.ts
@@ -16,6 +16,7 @@ export const syntheticUnitvariantLessonsByKsFixture = ({
   lesson_data: lessonDataFixture(),
   unit_data: unitDataFixture(),
   null_unitvariant_id: 1,
+  unitvariant_id: 1,
   programme_fields: programmeFieldsFixture(),
   order_in_unit: 1,
   ...overrides,

--- a/src/schema/syntheticUnitvariantLessons.schema.ts
+++ b/src/schema/syntheticUnitvariantLessons.schema.ts
@@ -12,6 +12,7 @@ export const syntheticUnitvariantLessonsSchema = z.object({
   lesson_data: lessonDataSchema,
   unit_data: unitDataSchema,
   null_unitvariant_id: z.number(),
+  unitvariant_id: z.number().nullish(),
   programme_fields: programmeFieldsSchema,
   supplementary_data: z.object({
     unit_order: z.number(),

--- a/src/schema/syntheticUnitvariantLessonsByKs.schema.ts
+++ b/src/schema/syntheticUnitvariantLessonsByKs.schema.ts
@@ -4,7 +4,6 @@ import { syntheticUnitvariantLessonsSchema } from "./syntheticUnitvariantLessons
 export const syntheticUnitvariantLessonsByKsSchema = z.object({
   ...syntheticUnitvariantLessonsSchema.omit({ supplementary_data: true }).shape,
   programme_slug_by_year: z.string().array(),
-  unitvariant_id: z.number(),
   order_in_unit: z.number(),
 });
 

--- a/src/schema/syntheticUnitvariantLessonsByKs.schema.ts
+++ b/src/schema/syntheticUnitvariantLessonsByKs.schema.ts
@@ -4,6 +4,7 @@ import { syntheticUnitvariantLessonsSchema } from "./syntheticUnitvariantLessons
 export const syntheticUnitvariantLessonsByKsSchema = z.object({
   ...syntheticUnitvariantLessonsSchema.omit({ supplementary_data: true }).shape,
   programme_slug_by_year: z.string().array(),
+  unitvariant_id: z.number(),
   order_in_unit: z.number(),
 });
 


### PR DESCRIPTION
Updates `syntheticUnitvariantLessonsByKsSchema` to include unitvariant id, this is required to fetch unit download zip files from the front end