### PR TITLE
feat: add features to schema

### DIFF
--- a/src/fixtures/features.fixture.ts
+++ b/src/fixtures/features.fixture.ts
@@ -1,0 +1,7 @@
+import type { Features } from "@/schema/features.schema";
+
+export const featuresFixture = (): Features => ({
+  pe_practical: true,
+});
+
+export default featuresFixture;

--- a/src/schema/features.schema.ts
+++ b/src/schema/features.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const featuresSchema = z
+  .object({
+    pe_practical: z.boolean(),
+  })
+  .partial();
+
+export type Features = z.infer<typeof featuresSchema>;

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,5 +1,6 @@
 export * from "./base.schema";
 export * from "./actions.schema";
+export * from "./features.schema";
 export * from "./lessonData.schema";
 export * from "./programmeFields.schema";
 export * from "./unitData.schema";

--- a/src/schema/syntheticUnitvariantLessons.schema.ts
+++ b/src/schema/syntheticUnitvariantLessons.schema.ts
@@ -3,6 +3,7 @@ import { lessonDataSchema } from "./lessonData.schema";
 import { unitDataSchema } from "./unitData.schema";
 import { programmeFieldsSchema } from "./programmeFields.schema";
 import { actionsSchema } from "./actions.schema";
+import { featuresSchema } from "./features.schema";
 
 export const syntheticUnitvariantLessonsSchema = z.object({
   lesson_slug: z.string(),
@@ -19,7 +20,7 @@ export const syntheticUnitvariantLessonsSchema = z.object({
     order_in_unit: z.number(),
   }),
   actions: actionsSchema.nullable().optional(),
-  features: z.object({}).optional().nullable(),
+  features: featuresSchema.nullable().optional(),
 });
 
 export type SyntheticUnitvariantLessons = z.infer<

--- a/src/test/features.test.ts
+++ b/src/test/features.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import featuresFixture from "@/fixtures/features.fixture";
+import { featuresSchema } from "@/schema/features.schema";
+
+describe("actions fixture", () => {
+  it("conforms to the schema", () => {
+    const l = featuresFixture();
+    expect(() => featuresSchema.parse(l)).not.toThrow();
+  });
+});


### PR DESCRIPTION
this is to get `features` in lessonOverview query so we can hide `Add teacher note and share` button for lesson with feature `{pe_practical: true}`