### PR TITLE
feat: media clips schema and fixtures cleanup

### DIFF
--- a/src/fixtures/mediaClips.fixture.ts
+++ b/src/fixtures/mediaClips.fixture.ts
@@ -1,4 +1,59 @@
-import { LessonMediaClips } from "@/schema/mediaClips.schema";
+import {
+  LessonMediaClips,
+  MediaClipObject,
+  VideoClipObject,
+  MediaClipCycle,
+} from "@/schema/mediaClips.schema";
+
+export const mediaObjectFixture = ({
+  overrides,
+}: {
+  overrides?: Partial<MediaClipObject>;
+} = {}): MediaClipObject => ({
+  url: "http://example.com/video1.mp3",
+  type: "upload",
+  bytes: 81127,
+  format: "mp3",
+  display_name: "9_task_C1_3",
+  resource_type: "video",
+  ...overrides,
+});
+
+export const videoObjectFixture = ({
+  overrides,
+}: {
+  overrides?: Partial<VideoClipObject>;
+} = {}): VideoClipObject => ({
+  duration: 5.055667,
+  mux_asset_id: "hug9i01Tnpf1y83irOm00HRbvAJpttJPU78KNYzPav3mg",
+  playback_ids: [
+    {
+      id: "mVkKUtOfoD1100012GNC1pCO6RvUgyGwqGoq01pYsy7WeA",
+      policy: "signed",
+    },
+    {
+      id: "BW00NkK9R01jB8PPO7R00YCFl2XBDn13GTkhd0001PNtheF00",
+      policy: "public",
+    },
+  ],
+  mux_playback_id: "BW00NkK9R01jB8PPO7R00YCFl2XBDn13GTkhd0001PNtheF00",
+  ...overrides,
+});
+
+export const mediaClipCycleFixture = ({
+  overrides,
+}: {
+  overrides?: Partial<MediaClipCycle>;
+} = {}): MediaClipCycle => ({
+  order: "1",
+  media_id: "191188",
+  video_id: 29844,
+  media_type: "video",
+  custom_title: "Intro Video 1",
+  media_object: mediaObjectFixture(),
+  video_object: videoObjectFixture(),
+  ...overrides,
+});
 
 export const mediaClipsFixture = ({
   overrides,
@@ -13,35 +68,8 @@ export const mediaClipsFixture = ({
         video_id: 29844,
         media_type: "video",
         custom_title: "Intro Video 1",
-        media_object: {
-          id: "4de4d70775b95bbc722d4d259fb033ad",
-          url: "http://example.com/video1.mp3",
-          type: "upload",
-          bytes: 81127,
-          format: "mp3",
-          duration: 5.041633,
-
-          display_name: "9_task_C1_3",
-          resource_type: "video",
-        },
-        video_object: {
-          id: "hug9i01Tnpf1y83irOm00HRbvAJpttJPU78KNYzPav3mg",
-
-          duration: 5.055667,
-
-          mux_asset_id: "hug9i01Tnpf1y83irOm00HRbvAJpttJPU78KNYzPav3mg",
-          playback_ids: [
-            {
-              id: "mVkKUtOfoD1100012GNC1pCO6RvUgyGwqGoq01pYsy7WeA",
-              policy: "signed",
-            },
-            {
-              id: "BW00NkK9R01jB8PPO7R00YCFl2XBDn13GTkhd0001PNtheF00",
-              policy: "public",
-            },
-          ],
-          mux_playback_id: "BW00NkK9R01jB8PPO7R00YCFl2XBDn13GTkhd0001PNtheF00",
-        },
+        media_object: mediaObjectFixture(),
+        video_object: videoObjectFixture(),
       },
       {
         order: "2",
@@ -50,21 +78,15 @@ export const mediaClipsFixture = ({
         media_type: "video",
         custom_title: "Intro Video 2",
         media_object: {
-          id: "e3331a6ee856256933cee73f7a62041b",
           url: "http://example.com/video2.mp3",
           type: "upload",
           bytes: 122087,
           format: "mp3",
-          duration: 7.601633,
-
           display_name: "8_task_C1_2",
           resource_type: "video",
         },
         video_object: {
-          id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
-
           duration: 7.603667,
-
           mux_asset_id: "gyUmSG2VVqcuw00NzT9f02kZvlLmXsrnuT5P7KhrYhWJg",
           playback_ids: [
             {
@@ -88,21 +110,15 @@ export const mediaClipsFixture = ({
         media_type: "video",
         custom_title: "",
         media_object: {
-          id: "3690e090829ca49c5506d6b90fd1106b",
           url: "http://oaknationalacademy-res.cloudinary.com/video/upload/v1736420414/u5bptym7h8ts8nyyrpwg.mp4",
           type: "upload",
           bytes: 276767,
           format: "mp4",
-          duration: 5.613111,
-
           display_name: "australia fact",
           resource_type: "video",
         },
         video_object: {
-          id: "4yb74fNKob6M6AT02AFTmsTrJEgXUl00WQWhpt01KttWcI",
-
           duration: 5.613111,
-
           mux_asset_id: "4yb74fNKob6M6AT02AFTmsTrJEgXUl00WQWhpt01KttWcI",
           playback_ids: [
             {
@@ -114,7 +130,6 @@ export const mediaClipsFixture = ({
               policy: "signed",
             },
           ],
-
           mux_playback_id: "RUIUNGcGf01kgZU1xC5peDCvGpC2d2YeRcwSMfJ4cvMk",
         },
       },
@@ -122,5 +137,21 @@ export const mediaClipsFixture = ({
   },
   ...overrides,
 });
+
+export const additionalCyclesFixture = {
+  media_clips: {
+    cycle3: [mediaClipCycleFixture()],
+    cycle4: [
+      mediaClipCycleFixture(),
+      mediaClipCycleFixture({
+        overrides: {
+          order: "2",
+          media_id: "1911749",
+          video_id: 298345,
+        },
+      }),
+    ],
+  },
+};
 
 export default mediaClipsFixture;

--- a/src/schema/mediaClips.schema.ts
+++ b/src/schema/mediaClips.schema.ts
@@ -1,53 +1,37 @@
 import { z } from "zod";
 
-// TODO: Schema is not complete so until data & structure is consistent is known partial() & nullish() being implemented
+export const mediaClipObjectSchema = z.object({
+  url: z.string(),
+  type: z.string(),
+  bytes: z.number(),
+  format: z.string(),
+  display_name: z.string(),
+  resource_type: z.string(),
+});
 
-export const clipMediaObjectSchema = z
-  .object({
-    id: z.string(),
-    url: z.string(),
-    type: z.string(),
-    bytes: z.number(),
-    format: z.string(),
-    duration: z.number().nullable(),
-    display_name: z.string(),
-    resource_type: z.string(),
-  })
-  .partial()
-  .nullish();
+export const videoClipObjectSchema = z.object({
+  duration: z.number().nullable(),
+  mux_asset_id: z.string(),
+  playback_ids: z.array(
+    z.object({
+      id: z.string(),
+      policy: z.string(),
+    }),
+  ),
+  mux_playback_id: z.string(),
+});
 
-export const clipVideoObjectSchema = z
-  .object({
-    id: z.string(),
-    duration: z.number().nullable(),
-    mux_asset_id: z.string(),
-    playback_ids: z.array(
-      z
-        .object({
-          id: z.string(),
-          policy: z.string(),
-        })
-        .partial()
-        .nullish(),
-    ),
-    mux_playback_id: z.string(),
-  })
-  .partial()
-  .nullish();
-
-export const mediaClipCycleSchema = z
-  .object({
-    // Test data had mixture of numbers and strings
-    order: z.number().or(z.string()),
-    media_id: z.number().or(z.string()),
-    video_id: z.number().nullable(),
-    media_type: z.string().nullish(),
-    custom_title: z.string().nullish(),
-    media_object: clipMediaObjectSchema,
-    video_object: clipVideoObjectSchema,
-  })
-  .partial()
-  .nullish();
+export const mediaClipCycleSchema = z.object({
+  // text data had a mix of numbers and strings
+  order: z.number().or(z.string()),
+  media_id: z.number().or(z.string()),
+  video_id: z.number().nullable(),
+  media_type: z.string().nullish(),
+  custom_title: z.string().nullish(),
+  media_object: mediaClipObjectSchema,
+  video_object: videoClipObjectSchema,
+  transcriptSentences: z.array(z.string()).nullish(),
+});
 
 export const mediaClipsRecordSchema = z.record(
   z.string(),
@@ -58,8 +42,8 @@ export const lessonMediaClipsSchema = z.object({
   media_clips: mediaClipsRecordSchema,
 });
 
-export type ClipMediaObject = z.infer<typeof clipMediaObjectSchema>;
-export type ClipVideoObject = z.infer<typeof clipVideoObjectSchema>;
+export type MediaClipObject = z.infer<typeof mediaClipObjectSchema>;
+export type VideoClipObject = z.infer<typeof videoClipObjectSchema>;
 export type MediaClipCycle = z.infer<typeof mediaClipCycleSchema>;
 export type MediaClipsRecord = z.infer<typeof mediaClipsRecordSchema>;
 export type LessonMediaClips = z.infer<typeof lessonMediaClipsSchema>;


### PR DESCRIPTION
- organize the schema for media clips
- we had a schema for media clips here and another schema for media clips in OWA so this one was't properly utilised
- extract fixtures for media and video objects as we need that for some tests in OWA
- one this si merged I will open another PR in OWA to utilise this version of schema