### PR TITLE
feat: update media clip object schema with attribution

### DIFF
--- a/src/schema/mediaClips.schema.ts
+++ b/src/schema/mediaClips.schema.ts
@@ -7,6 +7,12 @@ export const mediaClipObjectSchema = z.object({
   format: z.string(),
   display_name: z.string(),
   resource_type: z.string(),
+  metadata: z
+    .object({
+      attribution: z.string().nullish(),
+      attributionRequired: z.string().nullish(),
+    })
+    .nullish(),
 });
 
 export const videoClipObjectSchema = z


### PR DESCRIPTION
Update the media clip cycle schema to include selected fields on the media object metadata field required for rendering attributions on the media clips page.

See ticket with full details here https://www.notion.so/oaknationalacademy/I-want-attributions-on-the-media-clips-page-1eb26cc4e1b18052b0dfee1e1e74c6fa?source=copy_link