### PR TITLE
fix: remove unused legacy field for clarity

### DIFF
--- a/src/schema/mediaClips.schema.ts
+++ b/src/schema/mediaClips.schema.ts
@@ -10,7 +10,6 @@ export const mediaClipObjectSchema = z.object({
   metadata: z
     .object({
       attribution: z.string().nullish(),
-      attributionRequired: z.string().nullish(),
     })
     .nullish(),
 });


### PR DESCRIPTION
Removes `attributionRequired` from media clip metadata schema for clarity as this is a legacy field which shouldn't be used by the FE