### PR TITLE
feat: upgrade to zod 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "yalc": "^1.0.0-pre.53"
       },
       "peerDependencies": {
-        "zod": "^3.22.4"
+        "zod": "^4.1.11"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -11817,9 +11817,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "yalc": "^1.0.0-pre.53"
   },
   "peerDependencies": {
-    "zod": "^3.22.4"
+    "zod": "^4.1.11"
   },
   "repository": {
     "type": "git",

--- a/src/schema/lessonContent.schema.ts
+++ b/src/schema/lessonContent.schema.ts
@@ -82,7 +82,7 @@ export const lessonContentSchema = z.object({
   exit_quiz_id: z.number().nullable(),
   _state: _stateSchema,
   is_legacy: z.boolean().nullable(),
-  deprecated_fields: z.record(z.unknown()).nullable(),
+  deprecated_fields: z.record(z.string(), z.unknown()).nullable(),
   has_worksheet_google_drive_downloadable_version: z.boolean().nullable(),
   slide_deck_asset_id: z.number().nullable(),
   has_slide_deck_asset_object: z.boolean().nullable(),

--- a/src/schema/lessonData.schema.ts
+++ b/src/schema/lessonData.schema.ts
@@ -40,7 +40,7 @@ export const lessonDataSchema = z.object({
   expiration_date: z.string().nullable(),
   lesson_outline: z.array(lessonOutlineSchema).nullable().optional(),
   media_clips: mediaClipsRecordSchema.nullable().optional(),
-  deprecated_fields: z.record(z.unknown()).nullable(),
+  deprecated_fields: z.record(z.string(), z.unknown()).nullable(),
   _state: _stateSchema,
   _cohort: _cohortSchema,
   updated_at: z.string(),

--- a/src/schema/unitData.schema.ts
+++ b/src/schema/unitData.schema.ts
@@ -8,7 +8,7 @@ export const unitDataSchema = z.object({
   description: z.string().nullable(),
   slug: z.string(),
   tags: z.array(z.number()).nullable(),
-  deprecated_fields: z.record(z.unknown()).nullable().optional(),
+  deprecated_fields: z.record(z.string(), z.unknown()).nullable().optional(),
   title: z.string(),
   subjectcategories: z.array(z.union([z.number(), z.string()])).nullable(),
   prior_knowledge_requirements: z.array(z.string()).nullish(),


### PR DESCRIPTION
House Cat requires this change to enable peer dependcy updates

NB. this upgrade has breaking changes
see here https://zod.dev/v4/changelog

The only one which required changes was record. I have run this against the database contract tests and there are no failing tests.

OWA will be forced to upgrade to Zod 4 if this is merged so please check for any breaking changes.